### PR TITLE
fix: issue #10 - checkboxes should be checked when extension is installed

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,5 @@
 chrome.runtime.onInstalled.addListener(function (details) {
+  chrome.storage.local.clear()
   chrome.storage.local.set({
     config: [],
   });


### PR DESCRIPTION
Fixed the issue by clearing the local storage when extension is newly installed.